### PR TITLE
Update node version

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -9,5 +9,5 @@ outputs:
   time: # output will be available to future steps
     description: 'The message to output'
 runs:
-  using: 'node12'
+  using: 'node16'
   main: 'dist/index.js'


### PR DESCRIPTION
This PR updates the `action.yml` template to use node v16.

Node v16 is the [default for GitHub-hosted runners](https://github.blog/changelog/2021-12-10-github-actions-github-hosted-runners-now-run-node-js-16-by-default/) and is per 21.09.2022 the [LTS version](https://nodejs.org/en/) of node.